### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,5 +1,7 @@
 # Scan for secrets in the code
 name: gitleaks
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/PenguinOfThunder/wowbot/security/code-scanning/1](https://github.com/PenguinOfThunder/wowbot/security/code-scanning/1)

To fix the issue, add a `permissions` block at the workflow level to explicitly define the minimal permissions required. Since the workflow uses Gitleaks to scan for secrets, it only needs read access to the repository contents. Therefore, the `permissions` block should specify `contents: read`. This change ensures that the `GITHUB_TOKEN` cannot perform unintended actions, such as modifying repository contents.

The `permissions` block should be added at the root of the workflow file, just below the `name` field, so it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
